### PR TITLE
remove references to cloudfoundry-community

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,17 @@
-# Go CF Environment Package [![Build Status - Master](https://travis-ci.org/cloudfoundry-community/go-cfenv.svg?branch=master)](https://travis-ci.org/cloudfoundry-community/go-cfenv)
-
+# Go CF Environment Package
 ### Overview
-
-[![GoDoc](https://godoc.org/github.com/cloudfoundry-community/go-cfenv?status.png)](https://godoc.org/github.com/cloudfoundry-community/go-cfenv)
 
 `cfenv` is a package to assist you in writing Go apps that run on [Cloud Foundry](http://cloudfoundry.org). It provides convenience functions and structures that map to Cloud Foundry environment variable primitives (http://docs.cloudfoundry.org/devguide/deploy-apps/environment-variable.html).
 
 ### Usage
 
-`go get github.com/cloudfoundry-community/go-cfenv`
+`go get github.com/cloud-gov/go-cfenv`
 
 ```go
 package main
 
 import (
-	"github.com/cloudfoundry-community/go-cfenv"
+	"github.com/cloud-gov/go-cfenv"
 )
 
 func main() {

--- a/cfenv_test.go
+++ b/cfenv_test.go
@@ -4,7 +4,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/cloudfoundry-community/go-cfenv"
+	"github.com/cloud-gov/go-cfenv"
 	"github.com/mitchellh/mapstructure"
 	. "github.com/onsi/gomega"
 	"github.com/sclevine/spec"

--- a/environment_test.go
+++ b/environment_test.go
@@ -3,7 +3,7 @@ package cfenv_test
 import (
 	"testing"
 
-	"github.com/cloudfoundry-community/go-cfenv"
+	"github.com/cloud-gov/go-cfenv"
 	. "github.com/onsi/gomega"
 	"github.com/sclevine/spec"
 )


### PR DESCRIPTION
## Changes proposed in this pull request:

- Removes references to cloudfoundry-community so that we aren't accidentally redirecting people to the wrong repository
- Updates tests to reference cloud-gov instead of cloudfoundry-community

## Things to check

- For any logging statements, is there any chance that they could be logging sensitive data?
- Are log statements using a logging library with a logging level set? Setting a logging level means that log statements "below" that level will not be written to the output. For example, if the logging level is set to `INFO` and debugging statements are written with `log.debug` or similar, then they won't be written to the otput, which can prevent unintentional leaks of sensitive data.

## Security considerations

Updates documentation, and updates tests to use cloud-gov